### PR TITLE
Fix sidebar layout for mobile desktop view

### DIFF
--- a/_sass/_navigation.scss
+++ b/_sass/_navigation.scss
@@ -441,7 +441,7 @@
   }
 }
 
-@media (max-width: 1024px) {
+@media (max-width: $large) {
   .navbar-nav {
       display: flex;
       flex-wrap: wrap; /* Ensures menu items stay visible */

--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -139,7 +139,7 @@
 
 .sidebar .author__desktop {
   display: none;
-  @media screen and (min-width: 1024px) {
+  @media screen and (min-width: $large) {
     display: block;
   }
 }

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -46,7 +46,7 @@ $type-size-8                : 0.625em;  // ~10px
 $masthead-height            : 70px;
 
 /* Sidebar properties */
-$sidebar-screen-min-width   : 1024px;
+$sidebar-screen-min-width   : 960px;
 $sidebar-link-max-width     : 250px;
 
 
@@ -125,7 +125,7 @@ $x-large                    : 1800px;
 $small                      : 600px !default;
 $medium                     : 768px !default;
 $medium-wide                : 900px !default;
-$large                      : 925px !default;
+$large                      : 960px !default;
 $x-large                    : 1280px !default;
 
 /*


### PR DESCRIPTION
## Summary
- lower sidebar layout breakpoint to 960px so main content appears beside sidebar on mobile desktop
- use breakpoint variable for author sidebar display and nav menu wrapping

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_6892195f675883218e1625ed2db3f97d