### PR TITLE
Fix sidebar overlap on mobile desktop view

### DIFF
--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -47,7 +47,7 @@ $masthead-height            : 70px;
 
 /* Sidebar properties */
 
-$sidebar-screen-min-width   : 960px; // 1024 previously
+$sidebar-screen-min-width   : 1024px;
 $sidebar-link-max-width     : 250px;
 
 


### PR DESCRIPTION
## Summary
- raise desktop sidebar trigger to 1024px to avoid overlap on narrow screens

## Testing
- `npm run build:js`
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_b_68945d10b3f883218212a11940f27dc0